### PR TITLE
add memory info to django api

### DIFF
--- a/performance-storage-service/pss_project/api/models/rest/OLTPBenchRest.py
+++ b/performance-storage-service/pss_project/api/models/rest/OLTPBenchRest.py
@@ -14,39 +14,22 @@ class OLTPBenchRest(object):
 
     def convert_to_db_json(self):
         data = {
-            'time':
-            self.timestamp,
-            'git_branch':
-            self.metadata.github.git_branch,
-            'git_commit_id':
-            self.metadata.github.git_commit_id,
-            'jenkins_job_id':
-            self.metadata.jenkins.jenkins_job_id,
-            'db_version':
-            self.metadata.noisepage.db_version,
-            'environment':
-            convert_environment_to_dict(self.metadata.environment),
-            'benchmark_type':
-            self.type,
-            'query_mode':
-            self.parameters.query_mode,
-            'scale_factor':
-            self.parameters.scale_factor,
-            'terminals':
-            self.parameters.terminals,
-            'client_time':
-            self.parameters.client_time,
-            'weights':
-            convert_weights_to_dict(self.parameters.transaction_weights),
-            'wal_device':
-            self.metadata.environment.wal_device,
-            'max_connection_threads':
-            self.parameters.max_connection_threads,
-            'metrics':
-            convert_metrics_to_dict(self.metrics),
-            'incremental_metrics':
-            convert_incremental_metrics_to_dict(
-                self.metrics.incremental_metrics)
+            'time': self.timestamp,
+            'git_branch': self.metadata.github.git_branch,
+            'git_commit_id': self.metadata.github.git_commit_id,
+            'jenkins_job_id': self.metadata.jenkins.jenkins_job_id,
+            'db_version': self.metadata.noisepage.db_version,
+            'environment': convert_environment_to_dict(self.metadata.environment),
+            'benchmark_type': self.type,
+            'query_mode': self.parameters.query_mode,
+            'scale_factor': self.parameters.scale_factor,
+            'terminals': self.parameters.terminals,
+            'client_time': self.parameters.client_time,
+            'weights': convert_weights_to_dict(self.parameters.transaction_weights),
+            'wal_device': self.metadata.environment.wal_device,
+            'max_connection_threads': self.parameters.max_connection_threads,
+            'metrics': convert_metrics_to_dict(self.metrics),
+            'incremental_metrics': convert_incremental_metrics_to_dict(self.metrics.incremental_metrics)
         }
         return data
 

--- a/performance-storage-service/pss_project/api/models/rest/OLTPBenchRest.py
+++ b/performance-storage-service/pss_project/api/models/rest/OLTPBenchRest.py
@@ -1,7 +1,7 @@
 from pss_project.api.models.rest.metadata.Metadata import Metadata
 from pss_project.api.models.rest.parameters.OLTPBenchParameters import OLTPBenchParameters
 from pss_project.api.models.rest.metrics.OLTPBenchMetrics import OLTPBenchMetrics
-from pss_project.api.models.rest.utils import convert_environment_to_dict
+from pss_project.api.models.rest.utils import convert_environment_to_dict, to_dict
 
 
 class OLTPBenchRest(object):
@@ -14,22 +14,39 @@ class OLTPBenchRest(object):
 
     def convert_to_db_json(self):
         data = {
-            'time': self.timestamp,
-            'git_branch': self.metadata.github.git_branch,
-            'git_commit_id': self.metadata.github.git_commit_id,
-            'jenkins_job_id': self.metadata.jenkins.jenkins_job_id,
-            'db_version': self.metadata.noisepage.db_version,
-            'environment': convert_environment_to_dict(self.metadata.environment),
-            'benchmark_type': self.type,
-            'query_mode': self.parameters.query_mode,
-            'scale_factor': self.parameters.scale_factor,
-            'terminals': self.parameters.terminals,
-            'client_time': self.parameters.client_time,
-            'weights': convert_weights_to_dict(self.parameters.transaction_weights),
-            'wal_device': self.metadata.environment.wal_device,
-            'max_connection_threads': self.parameters.max_connection_threads,
-            'metrics': convert_metrics_to_dict(self.metrics),
-            'incremental_metrics': convert_incremental_metrics_to_dict(self.metrics.incremental_metrics)
+            'time':
+            self.timestamp,
+            'git_branch':
+            self.metadata.github.git_branch,
+            'git_commit_id':
+            self.metadata.github.git_commit_id,
+            'jenkins_job_id':
+            self.metadata.jenkins.jenkins_job_id,
+            'db_version':
+            self.metadata.noisepage.db_version,
+            'environment':
+            convert_environment_to_dict(self.metadata.environment),
+            'benchmark_type':
+            self.type,
+            'query_mode':
+            self.parameters.query_mode,
+            'scale_factor':
+            self.parameters.scale_factor,
+            'terminals':
+            self.parameters.terminals,
+            'client_time':
+            self.parameters.client_time,
+            'weights':
+            convert_weights_to_dict(self.parameters.transaction_weights),
+            'wal_device':
+            self.metadata.environment.wal_device,
+            'max_connection_threads':
+            self.parameters.max_connection_threads,
+            'metrics':
+            convert_metrics_to_dict(self.metrics),
+            'incremental_metrics':
+            convert_incremental_metrics_to_dict(
+                self.metrics.incremental_metrics)
         }
         return data
 
@@ -46,7 +63,8 @@ def convert_weights_to_dict(weights_list):
 def convert_metrics_to_dict(metrics):
     db_formatted_metrics = {
         'throughput': metrics.throughput,
-        'latency': metrics.latency.__dict__
+        'latency': metrics.latency.__dict__,
+        'memory_info': to_dict(metrics.memory_info),
     }
     return db_formatted_metrics
 
@@ -57,7 +75,8 @@ def convert_incremental_metrics_to_dict(incremental_metrics):
         db_formatted_incremental_json = {
             'time': metric.time,
             'throughput': metric.throughput,
-            'latency': metric.latency.__dict__
+            'latency': metric.latency.__dict__,
+            'memory_info': metric.memory_info.__dict__,
         }
         db_formatted_incremental_metrics.append(db_formatted_incremental_json)
     return db_formatted_incremental_metrics

--- a/performance-storage-service/pss_project/api/models/rest/metrics/BasePerformanceMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/BasePerformanceMetrics.py
@@ -1,8 +1,11 @@
 from pss_project.api.models.rest.metrics.LatencyMetrics import LatencyMetrics
+from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics
 
 
 class BasePerformanceMetrics(object):
-    def __init__(self, throughput, latency=None):
+    def __init__(self, throughput, latency=None, memory_info=None):
         self.throughput = throughput
         if latency:
             self.latency = LatencyMetrics(**latency)
+        if memory_info:
+            self.memory_info = MemoryMetrics(**memory_info)

--- a/performance-storage-service/pss_project/api/models/rest/metrics/IncrementalMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/IncrementalMetrics.py
@@ -2,6 +2,6 @@ from pss_project.api.models.rest.metrics.BasePerformanceMetrics import BasePerfo
 
 
 class IncrementalMetrics(BasePerformanceMetrics):
-    def __init__(self, time, throughput=None, latency=None):
+    def __init__(self, time, throughput=None, latency=None, memory_info=None):
         self.time = time
-        super().__init__(throughput, latency)
+        super().__init__(throughput, latency, memory_info)

--- a/performance-storage-service/pss_project/api/models/rest/metrics/MemoryMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/MemoryMetrics.py
@@ -1,0 +1,10 @@
+class MemoryItemSummary:
+    def __init__(self, avg=None):
+        if avg:
+            self.avg = avg
+
+
+class MemoryMetrics:
+    def __init__(self, rss, vms):
+        self.rss = rss
+        self.vms = vms

--- a/performance-storage-service/pss_project/api/models/rest/metrics/OLTPBenchMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/OLTPBenchMetrics.py
@@ -1,13 +1,15 @@
-from pss_project.api.models.rest.metrics.BasePerformanceMetrics import BasePerformanceMetrics
+from pss_project.api.models.rest.metrics.SummaryPerformanceMetrics import SummaryPerformanceMetrics
 from pss_project.api.models.rest.metrics.IncrementalMetrics import IncrementalMetrics
 
 
-class OLTPBenchMetrics(BasePerformanceMetrics):
-    def __init__(self, throughput, latency=None, incremental_metrics=None):
-        super().__init__(throughput, latency)
+class OLTPBenchMetrics(SummaryPerformanceMetrics):
+    def __init__(self,
+                 throughput,
+                 latency=None,
+                 memory_info=None,
+                 incremental_metrics=None):
+        super().__init__(throughput, latency, memory_info)
         if incremental_metrics:
             self.incremental_metrics = []
             for metric in incremental_metrics:
-                self.incremental_metrics.append(
-                    IncrementalMetrics(**metric)
-                )
+                self.incremental_metrics.append(IncrementalMetrics(**metric))

--- a/performance-storage-service/pss_project/api/models/rest/metrics/SummaryPerformanceMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/SummaryPerformanceMetrics.py
@@ -1,0 +1,13 @@
+from pss_project.api.models.rest.metrics.BasePerformanceMetrics import BasePerformanceMetrics
+from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, MemoryItemSummary
+
+
+class SummaryPerformanceMetrics(object):
+    def __init__(self, throughput, latency=None, memory_info=None):
+        super().__init__(throughput, latency)
+        if memory_info:
+            rss = MemoryItemSummary(
+                **memory_info["rss"]) if "rss" in memory_info else None
+            vms = MemoryItemSummary(
+                **memory_info["vms"]) if "vms" in memory_info else None
+            self.memory_info = MemoryMetrics(rss, vms)

--- a/performance-storage-service/pss_project/api/models/rest/metrics/SummaryPerformanceMetrics.py
+++ b/performance-storage-service/pss_project/api/models/rest/metrics/SummaryPerformanceMetrics.py
@@ -2,7 +2,7 @@ from pss_project.api.models.rest.metrics.BasePerformanceMetrics import BasePerfo
 from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, MemoryItemSummary
 
 
-class SummaryPerformanceMetrics(object):
+class SummaryPerformanceMetrics(BasePerformanceMetrics):
     def __init__(self, throughput, latency=None, memory_info=None):
         super().__init__(throughput, latency)
         if memory_info:

--- a/performance-storage-service/pss_project/api/models/rest/utils.py
+++ b/performance-storage-service/pss_project/api/models/rest/utils.py
@@ -5,3 +5,16 @@ def convert_environment_to_dict(environment):
         'cpu_socket': environment.cpu_socket
     }
     return db_formatted_environment
+
+
+def to_dict(obj):
+    """
+    Recursively turn an object to a Python dict
+    """
+    data = {}
+    for key, value in obj.__dict__.items():
+        try:
+            data[key] = to_dict(value)
+        except AttributeError:
+            data[key] = value
+    return data

--- a/performance-storage-service/pss_project/api/serializers/rest/metrics/IncrementalMetricsSerializer.py
+++ b/performance-storage-service/pss_project/api/serializers/rest/metrics/IncrementalMetricsSerializer.py
@@ -3,13 +3,18 @@ from pss_project.api.serializers.rest.metrics.LatencyMetricsSerializer \
     import LatencyMetricsSerializer
 from pss_project.api.models.rest.metrics.IncrementalMetrics \
     import IncrementalMetrics
+from pss_project.api.serializers.rest.metrics.MemoryMetricsSerializer \
+    import MemoryMetricsSerializer
 
 
 class IncrementalMetricsSerializer(Serializer):
     # Fields
     time = IntegerField()
-    throughput = DecimalField(max_digits=24, decimal_places=15, coerce_to_string=False)
+    throughput = DecimalField(max_digits=24,
+                              decimal_places=15,
+                              coerce_to_string=False)
     latency = LatencyMetricsSerializer(required=False)
+    memory_info = MemoryMetricsSerializer(required=False)
 
     def create(self, validated_data):
         return IncrementalMetrics(**validated_data)

--- a/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
+++ b/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
@@ -1,17 +1,17 @@
-from rest_framework.serializers import Serializer, DecimalField
+from rest_framework.serializers import Serializer, DecimalField, IntegerField
 from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, MemoryItemSummary
 
 
 class MemoryItemSummarySerializer(Serializer):
-    avg = DecimalField(decimal_places=4, coerce_to_string=False)
+    avg = DecimalField(max_digits=100, decimal_places=4, coerce_to_string=False)
 
     def create(self, validated_data):
         return MemoryItemSummarySerializer(**validated_data)
 
 
 class MemoryMetricsSerializer(Serializer):
-    rss = IntegerField()
-    vms = IntegerField()
+    rss = IntegerField(min_value=0)
+    vms = IntegerField(min_value=0)
 
     def create(self, validated_data):
         return MemoryMetrics(**validated_data)

--- a/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
+++ b/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
@@ -3,15 +3,15 @@ from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, Mem
 
 
 class MemoryItemSummarySerializer(Serializer):
-    avg = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
+    avg = DecimalField(decimal_places=4, coerce_to_string=False)
 
     def create(self, validated_data):
         return MemoryItemSummarySerializer(**validated_data)
 
 
 class MemoryMetricsSerializer(Serializer):
-    rss = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
-    vms = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
+    rss = IntegerField()
+    vms = IntegerField()
 
     def create(self, validated_data):
         return MemoryMetrics(**validated_data)

--- a/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
+++ b/performance-storage-service/pss_project/api/serializers/rest/metrics/MemoryMetricsSerializer.py
@@ -1,0 +1,25 @@
+from rest_framework.serializers import Serializer, DecimalField
+from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, MemoryItemSummary
+
+
+class MemoryItemSummarySerializer(Serializer):
+    avg = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
+
+    def create(self, validated_data):
+        return MemoryItemSummarySerializer(**validated_data)
+
+
+class MemoryMetricsSerializer(Serializer):
+    rss = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
+    vms = DecimalField(max_digits=10, decimal_places=4, coerce_to_string=False)
+
+    def create(self, validated_data):
+        return MemoryMetrics(**validated_data)
+
+
+class MemorySummaryMetricsSerializer(Serializer):
+    rss = MemoryItemSummarySerializer(required=False)
+    vms = MemoryItemSummarySerializer(required=False)
+
+    def create(self, validated_data):
+        return MemoryMetrics(**validated_data)

--- a/performance-storage-service/pss_project/api/serializers/rest/metrics/OLTPBenchMetricsSerializer.py
+++ b/performance-storage-service/pss_project/api/serializers/rest/metrics/OLTPBenchMetricsSerializer.py
@@ -1,4 +1,5 @@
 from rest_framework.serializers import Serializer, DecimalField
+from pss_project.api.serializers.rest.metrics.MemoryMetricsSerializer import MemorySummaryMetricsSerializer
 from pss_project.api.serializers.rest.metrics.LatencyMetricsSerializer import LatencyMetricsSerializer
 from pss_project.api.serializers.rest.metrics.IncrementalMetricsSerializer import IncrementalMetricsSerializer
 from pss_project.api.models.rest.metrics.OLTPBenchMetrics import OLTPBenchMetrics
@@ -6,9 +7,13 @@ from pss_project.api.models.rest.metrics.OLTPBenchMetrics import OLTPBenchMetric
 
 class OLTPBenchMetricsSerializer(Serializer):
     # Fields
-    throughput = DecimalField(max_digits=24, decimal_places=15, coerce_to_string=False)
+    throughput = DecimalField(max_digits=24,
+                              decimal_places=15,
+                              coerce_to_string=False)
     latency = LatencyMetricsSerializer(required=False)
-    incremental_metrics = IncrementalMetricsSerializer(required=False, many=True)
+    memory_info = MemorySummaryMetricsSerializer(required=False)
+    incremental_metrics = IncrementalMetricsSerializer(required=False,
+                                                       many=True)
 
     def create(self, validated_data):
         return OLTPBenchMetrics(**validated_data)

--- a/performance-storage-service/pss_project/api/tests/factories/rest/metrics/IncrementalMetricsFactory.py
+++ b/performance-storage-service/pss_project/api/tests/factories/rest/metrics/IncrementalMetricsFactory.py
@@ -2,6 +2,8 @@ from factory import Factory, Faker
 from pss_project.api.models.rest.metrics.IncrementalMetrics import IncrementalMetrics
 from pss_project.api.tests.factories.rest.metrics.LatencyMetricsFactory \
     import LatencyMetricsFactory
+from pss_project.api.tests.factories.rest.metrics.MemoryMetricsFactory \
+    import MemoryMetricsFactory
 
 
 class IncrementalMetricsFactory(Factory):
@@ -9,5 +11,9 @@ class IncrementalMetricsFactory(Factory):
         model = IncrementalMetrics
 
     time = Faker('random_int')
-    throughput = Faker('pydecimal', left_digits=9, right_digits=15, positive=True)
+    throughput = Faker('pydecimal',
+                       left_digits=9,
+                       right_digits=15,
+                       positive=True)
     latency = LatencyMetricsFactory().__dict__
+    memory_info = MemoryMetricsFactory().__dict__

--- a/performance-storage-service/pss_project/api/tests/factories/rest/metrics/MemoryMetricsFactory.py
+++ b/performance-storage-service/pss_project/api/tests/factories/rest/metrics/MemoryMetricsFactory.py
@@ -1,0 +1,25 @@
+from factory import Factory, Faker
+from pss_project.api.models.rest.metrics.MemoryMetrics import MemoryMetrics, MemoryItemSummary
+
+
+class MemoryInfoSummaryFactory(Factory):
+    class Meta:
+        model = MemoryItemSummary
+
+    avg = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
+
+
+class MemoryMetricsFactory(Factory):
+    class Meta:
+        model = MemoryMetrics
+
+    rss = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
+    vms = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
+
+
+class MemorySummaryMetricsFactory(Factory):
+    class Meta:
+        model = MemoryMetrics
+
+    rss = MemoryInfoSummaryFactory().__dict__
+    vms = MemoryInfoSummaryFactory().__dict__

--- a/performance-storage-service/pss_project/api/tests/factories/rest/metrics/MemoryMetricsFactory.py
+++ b/performance-storage-service/pss_project/api/tests/factories/rest/metrics/MemoryMetricsFactory.py
@@ -6,15 +6,15 @@ class MemoryInfoSummaryFactory(Factory):
     class Meta:
         model = MemoryItemSummary
 
-    avg = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
+    avg = Faker('pydecimal', left_digits=10, right_digits=4, positive=True)
 
 
 class MemoryMetricsFactory(Factory):
     class Meta:
         model = MemoryMetrics
 
-    rss = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
-    vms = Faker('pydecimal', left_digits=6, right_digits=4, positive=True)
+    rss = Faker('random_int')
+    vms = Faker('random_int')
 
 
 class MemorySummaryMetricsFactory(Factory):

--- a/performance-storage-service/pss_project/api/tests/factories/rest/metrics/OLTPBenchMetricsFactory.py
+++ b/performance-storage-service/pss_project/api/tests/factories/rest/metrics/OLTPBenchMetricsFactory.py
@@ -1,6 +1,7 @@
 from factory import Factory, Faker
 from pss_project.api.models.rest.metrics.OLTPBenchMetrics import OLTPBenchMetrics
 from pss_project.api.tests.factories.rest.metrics.LatencyMetricsFactory import LatencyMetricsFactory
+from pss_project.api.tests.factories.rest.metrics.MemoryMetricsFactory import MemorySummaryMetricsFactory
 from pss_project.api.tests.factories.rest.metrics.IncrementalMetricsFactory import IncrementalMetricsFactory
 from pss_project.api.tests.utils.utils import generate_dict_factory
 
@@ -9,12 +10,19 @@ class OLTPBenchMetricsFactory(Factory):
     class Meta:
         model = OLTPBenchMetrics
 
-    throughput = Faker('pydecimal', left_digits=9, right_digits=15, positive=True)
+    throughput = Faker('pydecimal',
+                       left_digits=9,
+                       right_digits=15,
+                       positive=True)
     latency = LatencyMetricsFactory().__dict__
-    incremental_metrics = Faker('random_elements', elements=(
-        generate_dict_factory(IncrementalMetricsFactory)(),
-        generate_dict_factory(IncrementalMetricsFactory)(),
-        generate_dict_factory(IncrementalMetricsFactory)(),
-        generate_dict_factory(IncrementalMetricsFactory)(),
-        generate_dict_factory(IncrementalMetricsFactory)(),
-    ), unique=True)
+    memory_info = MemorySummaryMetricsFactory().__dict__
+    incremental_metrics = Faker(
+        'random_elements',
+        elements=(
+            generate_dict_factory(IncrementalMetricsFactory)(),
+            generate_dict_factory(IncrementalMetricsFactory)(),
+            generate_dict_factory(IncrementalMetricsFactory)(),
+            generate_dict_factory(IncrementalMetricsFactory)(),
+            generate_dict_factory(IncrementalMetricsFactory)(),
+        ),
+        unique=True)

--- a/performance-storage-service/pss_project/api/tests/serializers/rest/test_basic_serializers.py
+++ b/performance-storage-service/pss_project/api/tests/serializers/rest/test_basic_serializers.py
@@ -11,11 +11,13 @@ from pss_project.api.tests.factories.rest.parameters.MicrobenchmarkParametersFac
     MicrobenchmarkParametersFactory)
 from pss_project.api.tests.factories.rest.metrics.OLTPBenchMetricsFactory import OLTPBenchMetricsFactory
 from pss_project.api.tests.factories.rest.metrics.LatencyMetricsFactory import LatencyMetricsFactory
+from pss_project.api.tests.factories.rest.metrics.MemoryMetricsFactory import (
+    MemoryInfoSummaryFactory, MemoryMetricsFactory,
+    MemorySummaryMetricsFactory)
 from pss_project.api.tests.factories.rest.metrics.IncrementalMetricsFactory import IncrementalMetricsFactory
 from pss_project.api.tests.factories.rest.metrics.MicrobenchmarkMetricsFactory import MicrobenchmarkMetricsFactory
 from pss_project.api.tests.factories.rest.OLTPBenchRestFactory import OLTPBenchRestFactory
 from pss_project.api.tests.factories.rest.MicrobenchmarkRestFactory import MicrobenchmarkRestFactory
-
 
 from pss_project.api.serializers.rest.metadata.GithubMetadataSerializer import GithubMetadataSerializer
 from pss_project.api.serializers.rest.metadata.JenkinsMetadataSerializer import JenkinsMetadataSerializer
@@ -29,6 +31,9 @@ from pss_project.api.serializers.rest.parameters.MicrobenchmarkParametersSeriali
 from pss_project.api.serializers.rest.metrics.OLTPBenchMetricsSerializer import OLTPBenchMetricsSerializer
 from pss_project.api.serializers.rest.metrics.MicrobenchmarkMetricsSerializer import MicrobenchmarkMetricsSerializer
 from pss_project.api.serializers.rest.metrics.LatencyMetricsSerializer import LatencyMetricsSerializer
+from pss_project.api.tests.factories.rest.metrics.MemoryMetricsSerializer import (
+    MemoryInfoSummarySerializer, MemoryMetricsSerializer,
+    MemorySummaryMetricsSerializer)
 from pss_project.api.serializers.rest.metrics.IncrementalMetricsSerializer import IncrementalMetricsSerializer
 from pss_project.api.serializers.rest.OLTPBenchSerializer import OLTPBenchSerializer
 from pss_project.api.serializers.rest.MicrobenchmarkSerializer import MicrobenchmarkSerializer
@@ -39,34 +44,46 @@ from pss_project.api.tests.utils.utils import generate_dict_factory
 class TestBasicSerializer(SimpleTestCase):
     # list of tests in the form (test_name, class_factory, class_serializer, excluded_fields)ƒ
     serializer_test_params = [
-        ('GithubMetadataSerializer', GithubMetadataFactory, GithubMetadataSerializer, []),
-        ('JenkinsMetadataSerializer', JenkinsMetadataFactory, JenkinsMetadataSerializer, []),
-        ('NoisePageMetadataSerializer', NoisePageMetadataFactory, NoisePageMetadataSerializer, []),
+        ('GithubMetadataSerializer', GithubMetadataFactory,
+         GithubMetadataSerializer, []),
+        ('JenkinsMetadataSerializer', JenkinsMetadataFactory,
+         JenkinsMetadataSerializer, []),
+        ('NoisePageMetadataSerializer', NoisePageMetadataFactory,
+         NoisePageMetadataSerializer, []),
         ('MetadataSerializer', MetadataFactory, MetadataSerializer, []),
-        ('EnvironmentMetadataSerializer', EnvironmentMetadataFactory, EnvironmentMetadataSerializer, []),
-
-        ('TransactionWeightSerializer', TransactionWeightFactory, TransactionWeightSerializer, []),
-        ('OLTPBenchParametersSerializer', OLTPBenchParametersFactory, OLTPBenchParametersSerializer, []),
-
-        ('MicrobenchmarkParametersSerializer',
-         MicrobenchmarkParametersFactory,
-         MicrobenchmarkParametersSerializer,
-         []
-         ),
-
-        ('OLTPBenchMetricsSerializer', OLTPBenchMetricsFactory, OLTPBenchMetricsSerializer, []),
-        ('LatencyMetricsSerializer', LatencyMetricsFactory, LatencyMetricsSerializer, []),
-        ('IncrementalMetricsSerializer', IncrementalMetricsFactory, IncrementalMetricsSerializer, []),
-
-        ('MicrobenchmarkMetricsSerializer', MicrobenchmarkMetricsFactory, MicrobenchmarkMetricsSerializer, []),
-
-        ('OLTPBenchSerializer', OLTPBenchRestFactory, OLTPBenchSerializer, ['timestamp']),
-        ('MicrobenchmarkSerializer', MicrobenchmarkRestFactory, MicrobenchmarkSerializer, ['timestamp']),
+        ('EnvironmentMetadataSerializer', EnvironmentMetadataFactory,
+         EnvironmentMetadataSerializer, []),
+        ('TransactionWeightSerializer', TransactionWeightFactory,
+         TransactionWeightSerializer, []),
+        ('OLTPBenchParametersSerializer', OLTPBenchParametersFactory,
+         OLTPBenchParametersSerializer, []),
+        ('MicrobenchmarkParametersSerializer', MicrobenchmarkParametersFactory,
+         MicrobenchmarkParametersSerializer, []),
+        ('OLTPBenchMetricsSerializer', OLTPBenchMetricsFactory,
+         OLTPBenchMetricsSerializer, []),
+        ('LatencyMetricsSerializer', LatencyMetricsFactory,
+         LatencyMetricsSerializer, []),
+        ('MemoryInfoSummaryMetricsSerializer', MemoryInfoSummaryFactory,
+         MemoryInfoSummaryMetricsSerializer, []),
+        ('MemoryMetricsSerializer', MemoryMetricsFactory,
+         MemoryMetricsSerializer, []),
+        ('MemorySummaryMetricsSerializer', MemorySummaryMetricsFactory,
+         MemorySummaryMetricsSerializer, []),
+        ('IncrementalMetricsSerializer', IncrementalMetricsFactory,
+         IncrementalMetricsSerializer, []),
+        ('MicrobenchmarkMetricsSerializer', MicrobenchmarkMetricsFactory,
+         MicrobenchmarkMetricsSerializer, []),
+        ('OLTPBenchSerializer', OLTPBenchRestFactory, OLTPBenchSerializer,
+         ['timestamp']),
+        ('MicrobenchmarkSerializer', MicrobenchmarkRestFactory,
+         MicrobenchmarkSerializer, ['timestamp']),
     ]
 
     def test_serialize_model_fields(self):
         for test_name, class_factory, class_serializer, excluded_fields in self.serializer_test_params:
-            with self.subTest(msg="{} serializer data fields matches the object.".format(test_name)):
+            with self.subTest(
+                    msg="{} serializer data fields matches the object.".format(
+                        test_name)):
                 input = class_factory()
                 serializer = class_serializer(input)
                 input_keys = list(input.__dict__.keys())
@@ -75,7 +92,8 @@ class TestBasicSerializer(SimpleTestCase):
 
     def test_deserialize_model_fields(self):
         for test_name, class_factory, class_serializer, excluded_fields in self.serializer_test_params:
-            with self.subTest(msg="Deserialization with {} is valid".format(test_name)):
+            with self.subTest(
+                    msg="Deserialization with {} is valid".format(test_name)):
                 ClassDictFactory = generate_dict_factory(class_factory)
                 input = ClassDictFactory()
                 serializer = class_serializer(data=input)

--- a/performance-storage-service/pss_project/api/views/oltpbench.py
+++ b/performance-storage-service/pss_project/api/views/oltpbench.py
@@ -11,25 +11,30 @@ class OLTPBenchViewSet(viewsets.ViewSet):
     """
     Store a new OLTPBench result in the datatbase
     """
-
     def create(self, request):
         user = BasicAuthentication().authenticate(request)
         if user is None:
-            return Response({'message': "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+            return Response({'message': "Forbidden"},
+                            status=status.HTTP_403_FORBIDDEN)
 
         data = JSONParser().parse(request)
         api_serializer = OLTPBenchSerializer(data=data)
         if not api_serializer.is_valid():
-            return Response(api_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(api_serializer.errors,
+                            status=status.HTTP_400_BAD_REQUEST)
 
         api_serializer.save()
-        db_serializer = OLTPBenchResultSerializer(data=api_serializer.instance.convert_to_db_json())
+        db_serializer = OLTPBenchResultSerializer(
+            data=api_serializer.instance.convert_to_db_json())
         if not db_serializer.is_valid():
-            return Response(db_serializer.errors, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(db_serializer.errors,
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         try:
             db_serializer.save()
         except Exception as e:
-            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response({'message': str(e)},
+                            status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        return Response(api_serializer.validated_data, status=status.HTTP_201_CREATED)
+        return Response(api_serializer.validated_data,
+                        status=status.HTTP_201_CREATED)

--- a/performance-storage-service/setup.cfg
+++ b/performance-storage-service/setup.cfg
@@ -10,3 +10,10 @@ exclude =
     env/*,
     */migrations/*,
     *__init__.py
+
+[yapf]
+max-line-length = 119
+exclude =
+    env/*,
+    */migrations/*,
+    *__init__.py


### PR DESCRIPTION
- created the base `MemoryMetrics` class and extended it for `MemorySummaryMetrics` for the memory info summary
- added the memory info to
  - db json schema
  - serializer
- added the test for
  - db factory
  - serializer