### PR TITLE
Hotfix prometheus storage limit

### DIFF
--- a/deployments/kubernetes/monitoring/prometheus/deployment.yml
+++ b/deployments/kubernetes/monitoring/prometheus/deployment.yml
@@ -1,5 +1,4 @@
 ---
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -24,9 +23,18 @@ spec:
       containers:
         - name: prometheus
           image: prom/prometheus:v2.2.1
+          resources:
+            requests:
+              memory: "1G"
+              cpu: "1"
+            limits:
+              memory: "2G"
+              cpu: "2"
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--storage.tsdb.retention.time=15d"
+            - "--storage.tsdb.retention.size=80GB"
             # FOR REVERSED PROXY
             - "--web.external-url=http://localhost:9090/prometheus"
             - "--web.route-prefix=/"

--- a/deployments/kubernetes/monitoring/prometheus/deployment.yml
+++ b/deployments/kubernetes/monitoring/prometheus/deployment.yml
@@ -22,7 +22,7 @@ spec:
         env: master
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.2.1
+          image: prom/prometheus:v2.22.2
           resources:
             requests:
               memory: "1G"

--- a/deployments/kubernetes/monitoring/prometheus/deployment.yml
+++ b/deployments/kubernetes/monitoring/prometheus/deployment.yml
@@ -34,7 +34,7 @@ spec:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
             - "--storage.tsdb.retention.time=15d"
-            - "--storage.tsdb.retention.size=80GB"
+            - "--storage.tsdb.retention.size=50GB"
             # FOR REVERSED PROXY
             - "--web.external-url=http://localhost:9090/prometheus"
             - "--web.route-prefix=/"


### PR DESCRIPTION
limit the prometheus resource consumption
- up to 2GB memory
- up to 2 core cpu
- up to the following, whichever comes first
  - 15 days' of data
  - 50GB data
