### PR TITLE
Hotfix: change ansible k8s module to communiy.kubernetes.

### DIFF
--- a/deployments/Jenkinsfile
+++ b/deployments/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
       steps {
         dir('deployments'){
           script{
+            sh "ansible-galaxy collection install community.kubernetes"
             sh "ansible-playbook -i inventory playbooks/create-namespaces.yml --key-file=${ANSIBLE_SSH} \
               --user=${ANSIBLE_SSH_USR} -e \"env=${env.ENV}\""
           }
@@ -65,6 +66,7 @@ pipeline {
         stage('TimescaleDB') {
           steps{
             dir('deployments'){
+              sh "ansible-galaxy collection install community.kubernetes"
               sh "ansible-playbook -i inventory playbooks/timescaledb-deployment.yml \
                 --key-file=${ANSIBLE_SSH} --user=${ANSIBLE_SSH_USR} -e env=${env.ENV}"
             }
@@ -73,6 +75,7 @@ pipeline {
         stage('Performance Storage Service') {
           steps{
             dir('deployments'){
+              sh "ansible-galaxy collection install community.kubernetes"
               sh "ansible-playbook -i inventory playbooks/pss-deployment.yml --key-file=${ANSIBLE_SSH} \
                 --user=${ANSIBLE_SSH_USR} -e env=${env.ENV}"
             }

--- a/deployments/playbooks/blackbox-exporter-deployment.yml
+++ b/deployments/playbooks/blackbox-exporter-deployment.yml
@@ -15,7 +15,7 @@
     - name: Apply blackbox_exporter deployment configs
       vars:
         config: "{{ dir_k8s_blackbox_exporter }}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/create-namespaces.yml
+++ b/deployments/playbooks/create-namespaces.yml
@@ -13,7 +13,7 @@
     register: create_namespaces
     vars:
       namespaces_file: "{{ dir_k8s }}/namespaces.yml"
-    k8s:
+    community.kubernetes.k8s:
       state: present
       definition: "{{ lookup('template', '{{ namespaces_file }}') }}"
 

--- a/deployments/playbooks/grafana-deployment.yml
+++ b/deployments/playbooks/grafana-deployment.yml
@@ -23,7 +23,7 @@
     - name: Apply Grafana Deployment Configs
       vars:
         config: "{{ dir_k8s_grafana }}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/monitoring-grafana-deployment.yml
+++ b/deployments/playbooks/monitoring-grafana-deployment.yml
@@ -16,7 +16,7 @@
     - name: Apply Grafana Deployment Configs
       vars:
         config: "{{ dir_k8s_grafana }}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/openapi-deployment.yml
+++ b/deployments/playbooks/openapi-deployment.yml
@@ -57,7 +57,7 @@
     - name: Apply Swagger OpenAPI Deployment Configs
       vars:
         config: "{{ dir_k8s_openapi }}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/postgres-exporter-deployment.yml
+++ b/deployments/playbooks/postgres-exporter-deployment.yml
@@ -15,7 +15,7 @@
     - name: Apply postgres_exporter deployment configs
       vars:
         config: "{{ dir_k8s_postgres_exporter}}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/prometheus-deployment.yml
+++ b/deployments/playbooks/prometheus-deployment.yml
@@ -15,7 +15,7 @@
     - name: Apply Prometheus Deployment Configs
       vars:
         config: "{{ dir_k8s_prometheus }}/{{ item }}"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ config }}') }}"
       loop:

--- a/deployments/playbooks/pss-deployment.yml
+++ b/deployments/playbooks/pss-deployment.yml
@@ -19,27 +19,27 @@
     - name: Remove Old Migration
       vars:
         job_file: "{{ dir_k8s_pss }}/migration-job.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: absent
         definition: "{{ lookup('template', '{{ job_file }}') }}"
         
     - name: Migrate Database
       vars:
         job_file: "{{ dir_k8s_pss }}/migration-job.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ job_file }}') }}"
 
     - name: Create Performance Storage Service Deployment
       vars:
         deployment_file: "{{ dir_k8s_pss }}/deployment.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ deployment_file }}') }}"
 
     - name: Create Performance Service
       vars:
         service_file: "{{ dir_k8s_pss }}/service.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ service_file }}') }}" # Trigger

--- a/deployments/playbooks/timescaledb-deployment.yml
+++ b/deployments/playbooks/timescaledb-deployment.yml
@@ -28,28 +28,28 @@
     - name: Create Persistent Volume
       vars:
         persistent_volume_file: "{{ dir_k8s_timescaledb }}/persistent-volume.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ persistent_volume_file }}') }}"
 
     - name: Create Persistent Volume Claim
       vars:
         persistent_volume_claim_file: "{{ dir_k8s_timescaledb }}/persistent-volume-claim.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ persistent_volume_claim_file }}') }}"
 
     - name: Create TimescaleDB Deployment
       vars:
         deployment_file: "{{ dir_k8s_timescaledb }}/deployment.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ deployment_file }}') }}"
 
     - name: Create TimescaleDB Service
       vars:
         service_file: "{{ dir_k8s_timescaledb }}/service.yml"
-      k8s:
+      community.kubernetes.k8s:
         state: present
         definition: "{{ lookup('template', '{{ service_file }}') }}"
     


### PR DESCRIPTION
- Installed `community.kubernetes` before each ansible playbook that uses `k8s`
- Changed `k8s` ansible module to `community.kubernetes.k8s` in each ansible playbook